### PR TITLE
Add forgotten ENV VAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ All vars needs to be set, no default values are provided.
 | ADMIN_TOKEN          | &lt;string&gt;                | some-secret         | Admin token used to access the /admin endpoints               |
 | DOCKER_API_URL       | &lt;url&gt;                   | http://10.0.0.125   | Url to docker api (must be available through port 80 for now) |
 | DOCKER_RUN_TIMEOUT   | &lt;seconds&gt;               | 30                  | Maximum number of seconds a container is allowed to run       |
+| MAX_OUTPUT_SIZE      | &lt;lines&gt;                 | 1000                | Maximum number of lines returned from a run                   |
 
 ## Api users
 An api token is required to run code. Users can be created with the `/admin/users` endpoint.


### PR DESCRIPTION
Need to initialize this variable or `glot-run` will crash when attempting to launch a run in a container.
