### PR TITLE
Fix Deprecated BIF: erlang:now/0

### DIFF
--- a/apps/glot/src/logging/event_log_srv.erl
+++ b/apps/glot/src/logging/event_log_srv.erl
@@ -49,7 +49,7 @@ terminate(Reason, #state{file=File}) ->
 
 append(Data) ->
     Data2 = Data#{
-        timestamp => iso8601:format(now()),
+        timestamp => iso8601:format(os:timestamp()),
         pid => util:pid_to_binary(self())
     },
     gen_server:cast(?MODULE, {append, Data2}).

--- a/apps/glot/src/logging/http_log_srv.erl
+++ b/apps/glot/src/logging/http_log_srv.erl
@@ -49,7 +49,7 @@ terminate(Reason, #state{file=File}) ->
 
 append(Data) ->
     Data2 = Data#{
-        timestamp => iso8601:format(now()),
+        timestamp => iso8601:format(os:timestamp()),
         pid => util:pid_to_binary(self())
     },
     gen_server:cast(?MODULE, {append, Data2}).

--- a/apps/glot/src/models/users.erl
+++ b/apps/glot/src/models/users.erl
@@ -36,7 +36,7 @@ delete(Id) ->
     user_srv:delete(Id).
 
 prepare_save(Data) ->
-    Now = iso8601:format(now()),
+    Now = iso8601:format(os:timestamp()),
     Data#{
         id => identifier(),
         created => Now,
@@ -45,7 +45,7 @@ prepare_save(Data) ->
 
 prepare_update(OldUser, NewUser) ->
     User = maps:merge(OldUser, NewUser),
-    Now = iso8601:format(now()),
+    Now = iso8601:format(os:timestamp()),
     User#{
         modified := Now
     }.


### PR DESCRIPTION
Removes this warning:

```
===> Compiling glot
/glot-run/_build/default/lib/glot/src/models/users.erl:39: Warning: erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information.
/glot-run/_build/default/lib/glot/src/models/users.erl:48: Warning: erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information.

/glot-run/_build/default/lib/glot/src/logging/http_log_srv.erl:52: Warning: erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information.

/glot-run/_build/default/lib/glot/src/logging/event_log_srv.erl:52: Warning: erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information.

```
